### PR TITLE
Minor doc improvement to navigation section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,13 @@ Instead
 
 ```python
 # option 1
-set_url_hash('home') # anvil's built in method
+set_url_hash('articles') # anvil's built in method
+
+# or an empty string to navigate to home page
+set_url_hash('')
 
 # option 2
-routing.set_url_hash('home') #routing's set_url_method has some bonus features... 
+routing.set_url_hash('articles') #routing's set_url_method has some bonus features... 
 
 # option 3
 routing.load_form(Home)


### PR DESCRIPTION
In its current place (after outlining the form route definitions), `set_url_hash('home')` was implying that the `home` would be a path available after the `HomeForm` was decorated. But `home` is an explicit page name that needs to be defined.

In this commit, I have replaced the `home` page name with a more generic `articles` string and also added a separate example for `home`.