### PR TITLE
README - Add example on dynamically setting Page Title

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,20 @@ class ArticleForm(ArticleFormTemplate):
 - Think `f strings` without the f
 - Anything in curly braces should be an item from `url_keys`
 
+You can also dynamically set the page title, for example, to values loaded from the database.
+
+```python
+from anvil.js.window import document
+
+@routing.route('article', url_keys=['id'])
+class ArticleForm(ArticleFormTemplate):
+  def __init__(self, **properties):
+    self.item = anvil.server.call('get_article', article_id=self.url_dict['id'])
+    document.title = f"{self.item['title']} | RoutingExample'"
+    
+    self.init_components(**properties)
+```
+
 ---
 
 


### PR DESCRIPTION
Instead of `id`, it makes more sense to show string values associated with the item being loaded in the Page Title. It is possible to use `anvil.js.window.document` to set the page title dynamically. This commit adds this useful piece of information to documentation.